### PR TITLE
Fixed function folding

### DIFF
--- a/ftplugin/php/phpfolding.vim
+++ b/ftplugin/php/phpfolding.vim
@@ -176,7 +176,7 @@ function! s:PHPCustomFolds() " {{{
 	"       'g:searchEmptyLinesPostfixing'..
 
 	" Fold function with PhpDoc (function foo() {})
-	call s:PHPFoldPureBlock('function', s:FOLD_WITH_PHPDOC)
+	call s:PHPFoldPureBlock('function\s\+[a-z_][a-z0-9_]*\s*(', s:FOLD_WITH_PHPDOC)
 
 	" Fold class properties with PhpDoc (var $foo = NULL;)
 	call s:PHPFoldProperties('^\s*\(\(private\)\|\(public\)\|\(protected\)\|\(var\)\)\s\(static\s\)*\$', ";", s:FOLD_WITH_PHPDOC, 1, 1)


### PR DESCRIPTION
It would incorrectly fold if use a $function variable or word. The following code would be fold incorrectly.

```php
foreach ( $foo as $function) {
}
```

This commit improves the function selector.